### PR TITLE
chore: create GHA workflow to deploy to Netlify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy Scalar Snippetz
+
+on:
+  push:
+    paths:
+      - 'demo/**'
+      - '.github/workflows/deploy.yml'
+    branches:
+      - 'main'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Scalar Snippetz
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Install netlify
+        run: pnpm install -g netlify
+      - name: Generate Run UUID
+        run: echo "DEPLOY_ID=$(uuidgen)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
+      - name: Install dependencies
+        run: pnpm install
+      - name: Turborepo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+      - name: Build
+        run: pnpm turbo run build
+        env:
+          DEPLOY_ID: ${{ env.DEPLOY_ID }}
+      - name: Deploy to netlify
+        run: |
+          netlify deploy --dir "./demo/dist" \
+          --message "Deployed from Github - ${{ env.DEPLOY_ID }}" \
+          --site ${{ vars.NETLIFY_SITE_ID_SNIPPETZ }} \
+          --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
+          --filter demo --prod


### PR DESCRIPTION
This PR adds a workflow to use GitHub actions to build and deploy the site to Netlify 

TODO: 
- [ ]  add to GHA environment 
     - [ ] `vars.NETLIFY_SITE_ID_SNIPPETZ`
     - [ ]  `secrets.NETLIFY_AUTH_TOKEN`
- [ ] change Netlify settings to manual deploy