### PR TITLE
chore: activate dependabot for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
-    open-pull-requests-limit: 0
+      interval: 'monthly'
+    open-pull-requests-limit: 5


### PR DESCRIPTION
This PR activates dependabot for monthly npm dependency updates.